### PR TITLE
Fix TAPAS starting with quality level 1 instead of 0

### DIFF
--- a/TapasPlayer.py
+++ b/TapasPlayer.py
@@ -24,7 +24,7 @@ class TapasPlayer(object):
     def __init__(self, controller, parser, media_engine, 
         log_sub_dir='', log_period=0.1,
         max_buffer_time=60,
-        inactive_cycle=1, initial_level=1,
+        inactive_cycle=1, initial_level=0,
         use_persistent_connection=True,
         check_warning_buffering=True,
         stress_test=False):

--- a/play.py
+++ b/play.py
@@ -85,7 +85,7 @@ def select_player():
     player = TapasPlayer(controller=controller, parser=parser, media_engine=media_engine,
         log_sub_dir=log_sub_dir, log_period=0.1,
         max_buffer_time=80,
-        inactive_cycle=1, initial_level=1,
+        inactive_cycle=1, initial_level=0,
         use_persistent_connection=persistent_conn,
         check_warning_buffering=check_warning_buffering,
         stress_test=options['stress_test'])


### PR DESCRIPTION
Hi,

I've noticed that TAPAS always starts fetching the video representation with quality level 1 first. Actually the lowest quality level available is 0. This commit fixes the issue.

Cheers
Patrick
